### PR TITLE
Version 4.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
 }
 
 ext {
-    vCoreVersion = "4.0.0"
+    vCoreVersion = "4.0.1"
     coreLibraryPackage = "collection-utils-core"
 
     kotlin_version = '1.3.50'

--- a/collection-utils-listview/src/main/java/com/guardanis/collections/list/adapters/ListViewAdapterViewModule.java
+++ b/collection-utils-listview/src/main/java/com/guardanis/collections/list/adapters/ListViewAdapterViewModule.java
@@ -10,9 +10,13 @@ import com.guardanis.collections.adapters.ModularAdapter;
 
 import java.lang.ref.WeakReference;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 public abstract class ListViewAdapterViewModule<T> extends AdapterViewModule<View> {
 
-    protected WeakReference<View> convertView;
+    @NonNull
+    protected WeakReference<View> convertView = new WeakReference<View>(null);
 
     public ListViewAdapterViewModule(int layoutResId) {
         super(layoutResId);
@@ -41,6 +45,7 @@ public abstract class ListViewAdapterViewModule<T> extends AdapterViewModule<Vie
 
     public abstract void updateView(ModularAdapter adapter, T item, int position);
 
+    @Nullable
     public View getConvertView(){
         return convertView.get();
     }

--- a/collection-utils-recyclerview/src/main/java/com/guardanis/collections/recycler/adapters/RecyclerViewModule.java
+++ b/collection-utils-recyclerview/src/main/java/com/guardanis/collections/recycler/adapters/RecyclerViewModule.java
@@ -1,9 +1,9 @@
 package com.guardanis.collections.recycler.adapters;
 
-import com.guardanis.collections.adapters.AdapterViewModule;
+import androidx.recyclerview.widget.RecyclerView;
 
 @Deprecated
-public abstract class RecyclerViewModule<T> extends AdapterViewModule<T> {
+public abstract class RecyclerViewModule<T, H extends RecyclerView.ViewHolder> extends RecyclerViewAdapterViewModule<T, H> {
 
     public RecyclerViewModule(int layoutResId) {
         super(layoutResId);


### PR DESCRIPTION
Fixes #4 

+ Deprecated RecyclerViewModule should inherit from `RecyclerViewAdapterViewModule`, not base abstraction
+ ListViewAdapterViewModule.convertView instance should never be null

I am aware I'm going to violate semantic versioning on this one, but I'm classifying these as bug fixes I introduced in the 4.0.0 release.